### PR TITLE
fix: trustd to use "api" subcommand

### DIFF
--- a/src/main/java/org/trustify/operator/cdrs/v2alpha1/server/ServerDeployment.java
+++ b/src/main/java/org/trustify/operator/cdrs/v2alpha1/server/ServerDeployment.java
@@ -109,6 +109,7 @@ public class ServerDeployment extends CRUDKubernetesDependentResource<Deployment
                 .orElse(null);
 
         return new DeploymentSpecBuilder()
+                .withMinReadySeconds(2)
                 .withStrategy(new DeploymentStrategyBuilder()
                         .withType("Recreate")
                         .build()

--- a/src/main/java/org/trustify/operator/cdrs/v2alpha1/server/ServerDeployment.java
+++ b/src/main/java/org/trustify/operator/cdrs/v2alpha1/server/ServerDeployment.java
@@ -135,7 +135,7 @@ public class ServerDeployment extends CRUDKubernetesDependentResource<Deployment
                                         .withImage(image)
                                         .withImagePullPolicy(imagePullPolicy)
                                         .withEnv(envVars)
-                                        .withCommand("/usr/local/bin/trustd", "server", "--devmode")
+                                        .withCommand("/usr/local/bin/trustd", "api", "--devmode")
                                         .withPorts(
                                                 new ContainerPortBuilder()
                                                         .withName("http")

--- a/src/test/java/org/trustify/operator/controllers/TrustifyReconcilerTest.java
+++ b/src/test/java/org/trustify/operator/controllers/TrustifyReconcilerTest.java
@@ -142,7 +142,7 @@ public class TrustifyReconcilerTest {
                             .toList();
                     Assertions.assertTrue(webContainerPorts.contains(8080), "Server container port 8080 not found");
 
-                    Assertions.assertEquals(1, serverDeployment.getStatus().getReadyReplicas(), "Expected Server deployment number of replicas doesn't match");
+                    Assertions.assertEquals(1, serverDeployment.getStatus().getAvailableReplicas(), "Expected Server deployment number of replicas doesn't match");
 
                     // Server service
                     final var serverService = client.services()


### PR DESCRIPTION
Also making sure the tests catch future errors when the pod is not able be running as currently readiness and liveness are disabled for the server